### PR TITLE
feat(Application.yml): AWS SSM을 통해 비밀 설정 정보 관리 (#19)

### DIFF
--- a/pumping/build.gradle.kts
+++ b/pumping/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id("org.springframework.boot") version "3.1.0"
+	id("org.springframework.boot") version "3.0.4"
 	id("io.spring.dependency-management") version "1.1.0"
 	kotlin("jvm") version "1.7.20"
 	kotlin("plugin.spring") version "1.7.20"
@@ -21,7 +21,10 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	implementation(platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.0"))
+	implementation("io.awspring.cloud:spring-cloud-aws-starter-parameter-store")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 }
 
 tasks.withType<KotlinCompile> {

--- a/pumping/src/main/kotlin/com/dpm/pumping/common/driver/Mongo.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/common/driver/Mongo.kt
@@ -9,7 +9,7 @@ import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoClients
 import com.mongodb.client.MongoDatabase
 
-@Component
+//@Component
 class Mongo(
     @Value("\${mongodb.databaseName}")
     private val databaseName: String,

--- a/pumping/src/main/kotlin/com/dpm/pumping/common/driver/MongoConfig.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/common/driver/MongoConfig.kt
@@ -1,0 +1,31 @@
+package com.dpm.pumping.common.driver
+
+import com.mongodb.MongoCredential
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.mongodb.core.MongoClientFactoryBean
+
+@Configuration
+class MongoConfig(
+    @Value("\${mongodb.databaseName}")
+    private val databaseName: String,
+
+    @Value("\${mongodb.mongoUri}")
+    private val mongoUri: String,
+
+    @Value("\${mongodb.username}")
+    private val username: String,
+
+    @Value("\${mongodb.password}")
+    private val password: String
+) {
+
+    @Bean
+    fun mongo(): MongoClientFactoryBean {
+        val mongo = MongoClientFactoryBean()
+        mongo.setHost(mongoUri)
+        mongo.setCredential(arrayOf(MongoCredential.createCredential(username, databaseName, password.toCharArray())))
+        return mongo
+    }
+}

--- a/pumping/src/main/resources/application.yml
+++ b/pumping/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+config:
+  type: aws-parameterstore:/config/pumping
+
+spring:
+  config:
+    import: ${config.type}
+
+  main:
+    allow-bean-definition-overriding: true
+
+mongodb:
+  databaseName: pumping
+  mongoUri: ${.mongo.uri}
+  username: ${.mongo.username}
+  password: ${.mongo.password}
+

--- a/pumping/src/main/resources/application.yml
+++ b/pumping/src/main/resources/application.yml
@@ -5,9 +5,6 @@ spring:
   config:
     import: ${config.type}
 
-  main:
-    allow-bean-definition-overriding: true
-
 mongodb:
   databaseName: pumping
   mongoUri: ${.mongo.uri}

--- a/pumping/src/main/resources/properties
+++ b/pumping/src/main/resources/properties
@@ -1,7 +1,0 @@
-server.port=
-spring.main.allow-bean-definition-overriding=true
-
-mongodb.databaseName="pumping"
-mongodb.mongoUri=
-mongodb.username=
-mongodb.password=


### PR DESCRIPTION
### ☁️ 개요
+ #19 

### 🎨 작업 내용
+ AWS SSM 파라미터 스토어를 통해 설정 정보 관리

### 🧚🏻 주의 사항
+ [파라미터 스토어](https://ap-northeast-2.console.aws.amazon.com/systems-manager/parameters/?region=ap-northeast-2&tab=Table) 에서 뒷 부분만 바꿔서 추가해주시면 되고, yml로 가져올때는 앞에 `.` 붙이면 됩니다. (ex) `{.mongo.password}` )
<img width="291" alt="스크린샷 2023-05-30 오후 10 35 45" src="https://github.com/depromeet/pumping-server/assets/71436576/d81ecafc-85ce-4ea0-9d6a-90a01d238cfc">

+ 각자 로컬에서 AWS 권한 인증 필요할꺼라 CSV 파일 슬랙에 올려놓겠습니다. EC2는 나중에 생성하면 콘솔에 설정해놓을게요
```bash
$ vim ~/.aws/credentials

[default]
--
aws_access_key_id=생성된 access_key_id
aws_secret_access_key=생성된 secret_access_key

$ vim ~/.aws/config

[default]
region=ap-northeast-2
output=json
```

close #19 