### PR TITLE
fix: action ec2 gradle build error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ on:
     push:
         branches:
             - develop
-            - feature/84
             
 jobs:
     ### Deprecate Deploy to NCP

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ on:
     push:
         branches:
             - develop
+            - feature/84
             
 jobs:
     ### Deprecate Deploy to NCP

--- a/pumping/Makefile
+++ b/pumping/Makefile
@@ -8,6 +8,7 @@ build-and-run-local:
 
 build-and-run-aws:
 	chmod +x $(CUR_DIR)/gradlew
+	$(CUR_DIR)/gradlew clean
 	$(CUR_DIR)/gradlew bootJar --parallel -Pprofile=aws
 	nohup java -jar $(CUR_DIR)/build/libs/pumping-0.0.1-SNAPSHOT.jar > log.log 2>&1 &
 


### PR DESCRIPTION
### ☁️ 개요
+ #84

### 레독 빌드 완료
http://15.165.13.148:8080/docs/crew/crew.html

### 문제 원인
- 인스턴스가 작음 (현재 그래들 빌드 환경의 몸집이 너무 큼)
- Action 에서 정상 빌드 및 배포되었다고 해도, SSH 연결 로그만 출력되는 상황이기 때문에 실제 반영여부를 알수 없음

### 임시 조치 방안
- gradle clean 명령어 분리 및 ec2 먹통시 웹 콘솔에서 재부팅

### 이슈 닫기
close #84
