### PR TITLE
feat: GET all users associated with the crew, workout data lookup API

### DIFF
--- a/pumping/src/main/kotlin/com/dpm/pumping/auth/config/AuthConfig.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/auth/config/AuthConfig.kt
@@ -16,8 +16,10 @@ class AuthConfig(
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(AuthInterceptor(jwtTokenProvider))
             .addPathPatterns("/**")
-            .excludePathPatterns("/docs/**", "/health","/error")
-            .excludePathPatterns("/api/v1/oauth2/**","/api/v1/sign-up")
+            .excludePathPatterns("/docs/**", "/health", "/error")
+            .excludePathPatterns("/api/v1/oauth2/**", "/api/v1/sign-up")
+            // 빠른 기능 개발을 위한 임시 조치
+            .excludePathPatterns("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**")
     }
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {

--- a/pumping/src/main/kotlin/com/dpm/pumping/auth/config/AuthConfig.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/auth/config/AuthConfig.kt
@@ -20,7 +20,7 @@ class AuthConfig(
             .excludePathPatterns("/api/v1/oauth2/**", "/api/v1/sign-up")
             // 빠른 기능 개발을 위한 임시 조치
             .excludePathPatterns("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**")
-            .excludePathPatterns("/home/**")
+            .excludePathPatterns("/bypass/**")
     }
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {

--- a/pumping/src/main/kotlin/com/dpm/pumping/auth/config/AuthConfig.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/auth/config/AuthConfig.kt
@@ -20,6 +20,7 @@ class AuthConfig(
             .excludePathPatterns("/api/v1/oauth2/**", "/api/v1/sign-up")
             // 빠른 기능 개발을 위한 임시 조치
             .excludePathPatterns("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**")
+            .excludePathPatterns("/home/**")
     }
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {

--- a/pumping/src/main/kotlin/com/dpm/pumping/auth/domain/LoginType.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/auth/domain/LoginType.kt
@@ -1,5 +1,5 @@
 package com.dpm.pumping.auth.domain
 
 enum class LoginType {
-    APPLE
+    APPLE, GOOGLE, KAKAO, NAVER, FACEBOOK
 }

--- a/pumping/src/main/kotlin/com/dpm/pumping/crew/Crew.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/crew/Crew.kt
@@ -11,12 +11,12 @@ import java.util.*
 @Document(collection = "crew")
 data class Crew(
     @Id
-    val crewId: String?,
-    val crewName: String?,
-    val code: String?,
-    val createDate: String?,
-    val goalCount: Int?,
-    val participants: List<String?>
+    var crewId: String?,
+    var crewName: String?,
+    var code: String?,
+    var createDate: String?,
+    var goalCount: Int?,
+    var participants: List<String?>
 ){
     companion object {
         fun create(name: String, goalCount: Int, userId: String): Crew {

--- a/pumping/src/main/kotlin/com/dpm/pumping/home/HomeController.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/home/HomeController.kt
@@ -64,13 +64,28 @@ class HomeController(private val mongoTemplate: MongoTemplate) {
             )
         }
 
+        // 참여자 리스트 중에서 요청받은 userId를 가장 앞으로 옮긴다.
+        val participantsList = crewData.participants.toMutableList()
+        if (participantsList.contains(userId)) {
+            participantsList.remove(userId)
+        }
+        participantsList.add(0, userId)
+
+        // 참여자 리스트 중에서 요청받은 운동데이터를 가장 앞으로 옮긴다.
+        val userIndex = memberInfoList.indexOfFirst { it.userId == userId }
+        if (userIndex != -1) {
+            val userWorkoutData = memberInfoList[userIndex]
+            memberInfoList.removeAt(userIndex)
+            memberInfoList.add(0, userWorkoutData)
+        }
+
         return HomeDataResponse(
             crewId = crewData.crewId,
             crewName = crewData.crewName,
             code = crewData.code,
             createDate = crewData.createDate,
             goalCount = crewData.goalCount,
-            participants = crewData.participants,
+            participants = participantsList,
             memberInfo = memberInfoList
         )
     }

--- a/pumping/src/main/kotlin/com/dpm/pumping/home/HomeController.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/home/HomeController.kt
@@ -1,0 +1,107 @@
+package com.dpm.pumping.home
+
+import com.dpm.pumping.crew.Crew
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.mapping.Document
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/home")
+class HomeController(private val mongoTemplate: MongoTemplate) {
+    private val logger: Logger = LoggerFactory.getLogger(HomeController::class.java)
+
+    @PostMapping("/crew")
+    fun getHomeData(@RequestBody request: HomeDataRequest): Any {
+        val crewId = request.crewId
+        val userId = request.userId
+
+        val crewData = fetchCrewData(crewId)
+        logger.info("[+] Fetched crewData: $crewData")
+        if (crewData == null) {
+            logger.error("[-] Failed to fetch crewData")
+            return "해당 크루 정보를 찾을 수 없습니다."
+        }
+
+
+        val userData = fetchUserData(userId)
+        logger.info("[+] Fetched userData: $userData")
+
+
+        return HomeDataResponse(
+            crewId = crewData.crewId,
+            crewName = crewData.crewName,
+            code = crewData.code,
+            createDate = crewData.createDate,
+            goalCount = crewData.goalCount,
+            participants = crewData.participants,
+            memberInfo = listOf(
+                MemberInfo(
+                    userId = "userId",
+                    userName = "userName",
+                    profileImage = "profileImage",
+                    workoutCount = 1,
+                    goalCount = 1,
+                    workoutTime = 1
+                )
+            )
+        )
+    }
+
+    private fun fetchCrewData(crewId: String): Crew? {
+        // DB에서 해당 crewId에 맞는 데이터를 가져온다.
+        val query = Query().addCriteria(Criteria.where("_id").`is`(crewId))
+        return mongoTemplate.findOne(query, Crew::class.java, "crew")
+    }
+
+    private fun fetchUserData(userId: String): String {
+        // DB에서 해당 userId에 맞는 데이터를 가져온다.
+        return "userData"
+    }
+
+    private fun fetchWorkoutData(crewId: String, userId: String): String {
+        return "workoutData"
+    }
+}
+
+data class HomeDataRequest(
+    val userId: String,
+    val crewId: String
+)
+
+data class HomeDataResponse(
+    val crewId: String?,
+    val crewName: String?,
+    val code: String?,
+    val createDate: String?,
+    val goalCount: Int?,
+    val participants: List<String?>,
+    val memberInfo: List<MemberInfo?>
+)
+
+data class MemberInfo(
+    val userId: String?,
+    val userName: String?,
+    val profileImage: String?,
+    val workoutCount: Int?,
+    val goalCount: Int?,
+    val workoutTime: Int?
+)
+
+@Document(collection = "crew")
+data class Crew(
+    @Id
+    val crewId: String?,
+    val crewName: String?,
+    val code: String?,
+    val createDate: String?,
+    val goalCount: Int?,
+    val participants: List<String?>
+)

--- a/pumping/src/main/kotlin/com/dpm/pumping/home/HomeController.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/home/HomeController.kt
@@ -1,6 +1,10 @@
 package com.dpm.pumping.home
 
-import com.dpm.pumping.crew.Crew
+import com.dpm.pumping.auth.config.LoginUser
+import com.dpm.pumping.auth.domain.LoginPlatform
+import com.dpm.pumping.auth.domain.LoginType
+import com.dpm.pumping.user.domain.CharacterType
+import com.dpm.pumping.user.domain.Gender
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.data.annotation.Id
@@ -8,15 +12,25 @@ import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.mapping.Document
 import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.data.mongodb.core.query.Query
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+import java.util.*
 
 @RestController
-@RequestMapping("/home")
+@RequestMapping("/bypass")
 class HomeController(private val mongoTemplate: MongoTemplate) {
     private val logger: Logger = LoggerFactory.getLogger(HomeController::class.java)
+
+    @PostMapping("/check/uid")
+    fun checkMyUserId(@LoginUser user: User): ResponseEntity<String> {
+        val response = user.uid
+        return response?.let { ResponseEntity(it, HttpStatus.OK) } ?: ResponseEntity(HttpStatus.NOT_FOUND)
+    }
 
     @PostMapping("/crew")
     fun getHomeData(@RequestBody request: HomeDataRequest): Any {
@@ -30,10 +44,21 @@ class HomeController(private val mongoTemplate: MongoTemplate) {
             return "해당 크루 정보를 찾을 수 없습니다."
         }
 
-
-        val userData = fetchUserData(userId)
-        logger.info("[+] Fetched userData: $userData")
-
+        val memberInfoList = mutableListOf<MemberInfo>()
+        crewData.participants.forEach { participantId ->
+            val userData = participantId?.let { fetchUserData(it) }
+            val workoutData = participantId?.let { fetchWorkoutData(crewId, it) }
+            memberInfoList.add(
+                MemberInfo(
+                    userId = participantId,
+                    userName = "userName",
+                    profileImage = "profileImage",
+                    workoutCount = 1,
+                    goalCount = 1,
+                    workoutTime = 1
+                )
+            )
+        }
 
         return HomeDataResponse(
             crewId = crewData.crewId,
@@ -61,47 +86,124 @@ class HomeController(private val mongoTemplate: MongoTemplate) {
         return mongoTemplate.findOne(query, Crew::class.java, "crew")
     }
 
-    private fun fetchUserData(userId: String): String {
+    private fun fetchUserData(userId: String): User? {
         // DB에서 해당 userId에 맞는 데이터를 가져온다.
-        return "userData"
+        val query = Query().addCriteria(Criteria.where("_id").`is`(userId))
+        return mongoTemplate.findOne(query, User::class.java, "user")
     }
 
     private fun fetchWorkoutData(crewId: String, userId: String): String {
         return "workoutData"
     }
+
+    @PostMapping("/create/random/user")
+    fun createRandomUser(): String {
+        val randomId = (1..999999).random().toString()
+        val randomName = "User-$randomId"
+        val randomGender = Gender.MALE  // Set appropriate gender here
+        val randomHeight = (100..200).random().toString()  // Set appropriate height here
+        val randomWeight = (50..100).random().toString()  // Set appropriate weight here
+        val randomPlatform =
+            LoginPlatform(loginType = LoginType.FACEBOOK, oauth2Id = "test01")  // Set appropriate platform here
+        val randomCharacterType = CharacterType.A  // Set appropriate characterType here
+        val currentCrew = null
+
+        val user = User(
+            uid = randomId,
+            name = randomName,
+            gender = randomGender,
+            height = randomHeight,
+            weight = randomWeight,
+            platform = randomPlatform,
+            characterType = randomCharacterType,
+            currentCrew = currentCrew
+        )
+
+        logger.info("[+] Created random user: $user")
+
+        mongoTemplate.save(user)
+
+        return user.uid.toString()
+    }
+
+    @PostMapping("/crew/join")
+    fun joinCrew(@RequestBody request: HomeDataRequest): Any {
+        val crewId = request.crewId
+        val userId = request.userId
+
+        val crewData = fetchCrewData(crewId)
+        logger.info("[+] Fetched crewData: $crewData")
+        if (crewData == null) {
+            logger.error("[-] Failed to fetch crewData")
+            return "해당 크루 정보를 찾을 수 없습니다."
+        }
+
+        val userData = fetchUserData(userId)
+        logger.info("[+] Fetched userData: $userData")
+        if (userData == null) {
+            logger.error("[-] Failed to fetch userData")
+            return "해당 유저 정보를 찾을 수 없습니다."
+        }
+
+        val crewParticipants = crewData.participants.toMutableList()
+        if (crewParticipants.contains(userId)) {
+            logger.error("[-] User is already in the crew")
+            return "이미 해당 크루에 참가하고 있습니다."
+        }
+        crewParticipants.add(userId.toString())
+        crewData.participants = crewParticipants.toMutableList()
+
+        mongoTemplate.save(crewData)
+
+        return "크루 참가에 성공했습니다."
+    }
+
+
+    data class HomeDataRequest(
+        val userId: String,
+        val crewId: String
+    )
+
+    data class HomeDataResponse(
+        val crewId: String?,
+        val crewName: String?,
+        val code: String?,
+        val createDate: String?,
+        val goalCount: Int?,
+        val participants: List<String?>,
+        val memberInfo: List<MemberInfo?>
+    )
+
+    data class MemberInfo(
+        val userId: String?,
+        val userName: String?,
+        val profileImage: String?,
+        val workoutCount: Int?,
+        val goalCount: Int?,
+        val workoutTime: Int?
+    )
+
+    @Document(collection = "crew")
+    data class Crew(
+        @Id
+        val crewId: String?,
+        val crewName: String?,
+        val code: String?,
+        val createDate: String?,
+        val goalCount: Int?,
+        var participants: List<String?>
+    )
+
+    @Document(collection = "user")
+    data class User(
+        @Id
+        var uid: String?,
+        var name: String?,
+        var gender: Gender?,
+        var height: String?,
+        var weight: String?,
+        var platform: LoginPlatform,
+        var characterType: CharacterType?,
+        var currentCrew: Crew?
+    )
 }
-
-data class HomeDataRequest(
-    val userId: String,
-    val crewId: String
-)
-
-data class HomeDataResponse(
-    val crewId: String?,
-    val crewName: String?,
-    val code: String?,
-    val createDate: String?,
-    val goalCount: Int?,
-    val participants: List<String?>,
-    val memberInfo: List<MemberInfo?>
-)
-
-data class MemberInfo(
-    val userId: String?,
-    val userName: String?,
-    val profileImage: String?,
-    val workoutCount: Int?,
-    val goalCount: Int?,
-    val workoutTime: Int?
-)
-
-@Document(collection = "crew")
-data class Crew(
-    @Id
-    val crewId: String?,
-    val crewName: String?,
-    val code: String?,
-    val createDate: String?,
-    val goalCount: Int?,
-    val participants: List<String?>
-)


### PR DESCRIPTION
### ☁️ 개요
+ #88 


### 🎨 작업 내용
+ 기존 인터셉터 인증로직을 우회하여, home 화면으로 crew 정보와 crew 안에 속해있는 참여자들의 데이터를 조회할 수 있는 기능


### 🧚🏻 주의 사항
+ 추후, 해당 HomeControler.kt 의 내용을 리펙토링해야 함
+ 아래 모든 내용은 테스트코드가 없는 상태임


### 참고 사항
+ /bypass/crew 에 {"userId": "string", "crewId": "string"} 요청 Body 를 통해 home 에 필요한 데이터를 전부 조회해올 수 있습니다.
+ 스웨거를 정상적으로 세팅하였습니다. (/swagger-ui/index.html)
+ 원할한 테스트를 위해 랜덤 유저 생성기를 추가하였습니다. (/bypass/create/ramdom/user)
+ 원할한 테스트를 위해 특정 유저를 다른 크루에 임의로 참여시키는 API를 구현하였습니다. (/bypass/crew/join)
+ 혹시라도 클라이언트에서 userId 를 잃어버릴 경우를 대비하여 기존의 header에 담긴 토큰 정보로부터 userId 를 반환하는 기능을 구현했습니다. (/bypass/check/uid)


### 이슈 닫기
close #88 
