### PR TITLE
feat: get workout data by week (#90)

### DIFF
--- a/pumping/src/main/kotlin/com/dpm/pumping/crew/Crew.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/crew/Crew.kt
@@ -2,9 +2,7 @@ package com.dpm.pumping.crew
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
-import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.Period
 import java.time.format.DateTimeFormatter
 import java.util.*
 
@@ -33,12 +31,6 @@ data class Crew(
         private fun generateCrewCode(): String {
             return (1..999999).random().toString().padStart(6, '0')
         }
-    }
-
-    fun calculateDays(workoutCreatedAt: LocalDate): Int {
-        val crewCreatedAt = LocalDate.parse(createDate, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-        val period = Period.between(crewCreatedAt, workoutCreatedAt)
-        return period.days + 1
     }
 }
 

--- a/pumping/src/main/kotlin/com/dpm/pumping/crew/Crew.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/crew/Crew.kt
@@ -1,5 +1,7 @@
 package com.dpm.pumping.crew
 
+import com.dpm.pumping.workout.application.WorkoutStorage
+import com.dpm.pumping.workout.util.CalenderUtils
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDateTime
@@ -16,6 +18,7 @@ data class Crew(
     val goalCount: Int?,
     val participants: List<String?>
 ){
+
     companion object {
         fun create(name: String, goalCount: Int, userId: String): Crew {
             return Crew(
@@ -31,6 +34,12 @@ data class Crew(
         private fun generateCrewCode(): String {
             return (1..999999).random().toString().padStart(6, '0')
         }
+    }
+
+    fun getStartDate(): LocalDateTime {
+        val startDate = LocalDateTime.parse(createDate!!)
+        val week = CalenderUtils.getWeek(startDate, LocalDateTime.now())
+        return startDate.plusDays((week - 1) * WorkoutStorage.DEFAULT_SIZE)
     }
 }
 

--- a/pumping/src/main/kotlin/com/dpm/pumping/workout/application/WorkoutService.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/workout/application/WorkoutService.kt
@@ -2,15 +2,15 @@ package com.dpm.pumping.workout.application
 
 import com.dpm.pumping.user.domain.User
 import com.dpm.pumping.user.domain.UserRepository
-import com.dpm.pumping.workout.application.WorkoutStorage.*
+import com.dpm.pumping.workout.application.WorkoutStorage.WorkoutByDay
 import com.dpm.pumping.workout.domain.entity.Workout
 import com.dpm.pumping.workout.dto.WorkoutCreateDto
 import com.dpm.pumping.workout.dto.WorkoutGetDto
 import com.dpm.pumping.workout.repository.WorkoutRepository
+import com.dpm.pumping.workout.util.CalenderUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @Service
 @Transactional(readOnly = true)
@@ -36,7 +36,7 @@ class WorkoutService(
         val crew = user.currentCrew
             ?: throw IllegalArgumentException("아직 크루에 참여하지 않아 운동 기록이 존재하지 않습니다.")
 
-        val startDate = LocalDateTime.parse(crew.createDate)
+        val startDate = crew.getStartDate()
         val endDate = startDate.plusDays(WorkoutStorage.DEFAULT_SIZE)
         val workoutDatas = workoutRepository
             .findAllByCurrentCrewAndUserIdAndCreateDateBetween(crew.crewId!!, user.uid!!, startDate.minusDays(1), endDate)
@@ -61,8 +61,8 @@ class WorkoutService(
 
     private fun getWorkoutDto(storage: Map<LocalDate, WorkoutByDay?>): List<WorkoutGetDto.WorkoutResponse> {
         return storage.map { (key, value) ->
-            val dayOfWeek = key.dayOfWeek
-            WorkoutGetDto.WorkoutResponse(dayOfWeek.value.toString(), value)
+            val day = CalenderUtils.getDayOfWeek(key)
+            WorkoutGetDto.WorkoutResponse(day.toString(), value)
         }
     }
 }

--- a/pumping/src/main/kotlin/com/dpm/pumping/workout/application/WorkoutStorage.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/workout/application/WorkoutStorage.kt
@@ -1,0 +1,55 @@
+package com.dpm.pumping.workout.application
+
+import com.dpm.pumping.workout.domain.entity.Workout
+import java.time.LocalDate
+
+data class WorkoutStorage(
+    private val crewCreatedAt: LocalDate
+) {
+
+    companion object {
+        const val DEFAULT_SIZE = 7L
+    }
+
+    private val storage = mutableMapOf<LocalDate, WorkoutByDay?>()
+
+    init {
+        for (i in 0 until DEFAULT_SIZE) {
+            val key = crewCreatedAt.plusDays(i)
+            storage[key] = null
+        }
+    }
+
+    fun save(workout: Workout) {
+        val key = workout.createDate.toLocalDate()
+        val data = WorkoutByDay.from(workout, crewCreatedAt)
+        storage[key] = data
+    }
+
+    data class WorkoutByDay(
+        val workoutDate: String,
+        val totalTime: Int,
+        val averageHeartbeat: Int,
+        val totalCalories: Int,
+        val maxWorkoutCategory: String,
+        val maxWorkoutCategoryTime: Int
+    ) {
+        companion object {
+            fun from(workout: Workout, crewCreatedAt: LocalDate): WorkoutByDay {
+                val maxWorkoutData = workout.getMaxWorkoutPart()
+                return WorkoutByDay(
+                    workoutDate = workout.calculateDays(crewCreatedAt).toString(),
+                    totalTime = workout.getTotalTime(),
+                    averageHeartbeat = workout.getAverageHeartbeat(),
+                    totalCalories = workout.getTotalCalories(),
+                    maxWorkoutCategory = maxWorkoutData.first.name,
+                    maxWorkoutCategoryTime = maxWorkoutData.second
+                )
+            }
+        }
+    }
+
+    fun get(): Map<LocalDate, WorkoutByDay?> {
+        return storage.toMap()
+    }
+}

--- a/pumping/src/main/kotlin/com/dpm/pumping/workout/domain/entity/Workout.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/workout/domain/entity/Workout.kt
@@ -4,7 +4,10 @@ import com.dpm.pumping.workout.domain.WorkoutCategory
 import com.dpm.pumping.workout.dto.WorkoutCreateDto.TimerDto
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.Period
+import java.time.format.DateTimeFormatter
 import java.util.*
 
 @Document(collection = "workout")
@@ -48,6 +51,12 @@ data class Workout(
         return timers.groupBy { WorkoutCategory.getByPart(it.workoutPart) }
             .map { it.key to it.value.sumOf { timer -> timer.time.toInt() } }
             .maxByOrNull { v -> v.second }!!
+    }
+
+    fun calculateDays(crewCreatedAt: LocalDate): Int {
+        val workoutCreatedAt = createDate.toLocalDate()
+        val period = Period.between(crewCreatedAt, workoutCreatedAt)
+        return period.days + 1
     }
 
 

--- a/pumping/src/main/kotlin/com/dpm/pumping/workout/dto/WorkoutGetDto.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/workout/dto/WorkoutGetDto.kt
@@ -1,17 +1,15 @@
 package com.dpm.pumping.workout.dto
 
+import com.dpm.pumping.workout.application.WorkoutStorage
+
 class WorkoutGetDto {
 
     data class Response(
-        val workouts: List<WorkoutByDay>?
+        val workouts: List<WorkoutResponse>
     )
 
-    data class WorkoutByDay(
-        val workoutDate: String,
-        val totalTime: Int,
-        val averageHeartbeat: Int,
-        val totalCalories: Int,
-        val maxWorkoutCategory: String,
-        val maxWorkoutCategoryTime: Int
+    data class WorkoutResponse(
+        val dayOfWeek: String,
+        val workout: WorkoutStorage.WorkoutByDay?
     )
 }

--- a/pumping/src/main/kotlin/com/dpm/pumping/workout/util/CalenderUtils.kt
+++ b/pumping/src/main/kotlin/com/dpm/pumping/workout/util/CalenderUtils.kt
@@ -1,0 +1,22 @@
+package com.dpm.pumping.workout.util
+
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+
+object CalenderUtils {
+
+    private const val TOTAL_DAYS_OF_WEEK = 7
+
+    fun getDayOfWeek(date: LocalDate): Int {
+        val dayOfWeek = date.dayOfWeek
+        return dayOfWeek.value
+    }
+
+    fun getWeek(startDate: LocalDateTime, curDate: LocalDateTime): Int {
+        val duration = Duration.between(startDate, curDate).toDays()
+        val week = (duration / TOTAL_DAYS_OF_WEEK) + 1
+        return week.toInt()
+    }
+}

--- a/pumping/src/test/kotlin/com/dpm/pumping/workout/application/WorkoutServiceTest.kt
+++ b/pumping/src/test/kotlin/com/dpm/pumping/workout/application/WorkoutServiceTest.kt
@@ -87,32 +87,26 @@ class WorkoutServiceTest @Autowired constructor(
         val crew2 = createCrew("crew02")
         val testUser = createUser(currentCrew = crew1)
         val timer = createTimer(WorkoutPart.ARM)
-        val crew1FirstDayWorkout = createWorkout(listOf(timer), "2023-06-22T10:00:00", crew1.crewId!!, testUser)
-        val crew1SecondDayWorkout = createWorkout(listOf(timer), "2023-06-23T10:00:00", crew1.crewId!!, testUser)
-        val crew1ThirdDayWorkout = createWorkout(listOf(timer), "2023-06-24T10:00:00", crew1.crewId!!, testUser)
-        val crew1FourthDayWorkout = createWorkout(listOf(timer), "2023-06-25T10:00:00", crew1.crewId!!, testUser)
-        val crew1FifthDayWorkout = createWorkout(listOf(timer), "2023-06-26T10:00:00", crew1.crewId!!, testUser)
-        val crew1SixDayWorkout = createWorkout(listOf(timer), "2023-06-27T10:00:00", crew1.crewId!!, testUser)
-        val crew1SevenDayWorkout = createWorkout(listOf(timer), "2023-06-28T10:00:00", crew1.crewId!!, testUser)
-        val crew1EightDayWorkout = createWorkout(listOf(timer), "2023-06-29T10:00:00", crew1.crewId!!, testUser)
+        for (i in 2 .. 8) {
+            val entity = createWorkout(listOf(timer), "2023-06-2${i}T10:00:00", crew1.crewId!!, testUser)
+            workoutRepository.save(entity)
+        }
 
         val crew2FirstDayWorkout = createWorkout(listOf(timer), "2023-06-23T10:00:00", crew2.crewId!!, testUser)
+         workoutRepository.save(crew2FirstDayWorkout)
 
-        workoutRepository.saveAll(listOf(
-            crew1FirstDayWorkout, crew1SecondDayWorkout, crew2FirstDayWorkout,
-            crew1ThirdDayWorkout, crew1FourthDayWorkout, crew1FifthDayWorkout,
-            crew1SixDayWorkout, crew1SevenDayWorkout, crew1EightDayWorkout
-        ))
         given(userRepository.findById(any())).willReturn(Optional.of(testUser))
 
         // when
         val response = workoutService.getWorkouts(null, testUser)
 
         // then
-        val result = response.workouts!!.toList()
+        val result = response.workouts
         assertThat(result.size).isEqualTo(7)
-        assertThat(result[0].workoutDate).isEqualTo("1")
-        assertThat(result[1].workoutDate).isEqualTo("2")
+        assertThat(result[0].dayOfWeek).isEqualTo("4")
+        assertThat(result[0].workout!!.workoutDate).isEqualTo("1")
+        assertThat(result[1].dayOfWeek).isEqualTo("5")
+        assertThat(result[1].workout!!.workoutDate).isEqualTo("2")
     }
 
     @Test
@@ -131,10 +125,10 @@ class WorkoutServiceTest @Autowired constructor(
         val result = workoutService.getWorkouts(null, testUser)
 
         // then
-        val values = result.workouts!!.toList()
-        assertThat(values[0].totalTime).isEqualTo(120)
-        assertThat(values[0].averageHeartbeat).isEqualTo(80)
-        assertThat(values[0].totalCalories).isEqualTo(200)
+        val values = result.workouts
+        assertThat(values[0].workout!!.totalTime).isEqualTo(120)
+        assertThat(values[0].workout!!.averageHeartbeat).isEqualTo(80)
+        assertThat(values[0].workout!!.totalCalories).isEqualTo(200)
     }
 
     @Test
@@ -154,9 +148,9 @@ class WorkoutServiceTest @Autowired constructor(
         val result = workoutService.getWorkouts(null, testUser)
 
         // then
-        val values = result.workouts!!.toList()
-        assertThat(values[0].maxWorkoutCategory).isEqualTo(WorkoutCategory.UP.name)
-        assertThat(values[0].maxWorkoutCategoryTime).isEqualTo(120)
+        val values = result.workouts
+        assertThat(values[0].workout!!.maxWorkoutCategory).isEqualTo(WorkoutCategory.UP.name)
+        assertThat(values[0].workout!!.maxWorkoutCategoryTime).isEqualTo(120)
     }
 
     private fun createTimer(workoutPart: WorkoutPart): Timer {

--- a/pumping/src/test/kotlin/com/dpm/pumping/workout/presentation/WorkoutControllerTest.kt
+++ b/pumping/src/test/kotlin/com/dpm/pumping/workout/presentation/WorkoutControllerTest.kt
@@ -9,6 +9,7 @@ import com.dpm.pumping.user.domain.Gender
 import com.dpm.pumping.user.domain.User
 import com.dpm.pumping.user.domain.UserRepository
 import com.dpm.pumping.workout.application.WorkoutService
+import com.dpm.pumping.workout.application.WorkoutStorage
 import com.dpm.pumping.workout.domain.WorkoutCategory
 import com.dpm.pumping.workout.domain.WorkoutPart
 import com.dpm.pumping.workout.dto.WorkoutCreateDto.*
@@ -127,13 +128,16 @@ class WorkoutControllerTest(
     fun getWorkouts() {
         val response = WorkoutGetDto.Response(
             listOf(
-                WorkoutGetDto.WorkoutByDay(
-                    workoutDate = "2023-06-22T10:00:00",
-                    totalTime = 60,
-                    averageHeartbeat = 120,
-                    totalCalories = 500,
-                    maxWorkoutCategory = WorkoutCategory.UP.name,
-                    maxWorkoutCategoryTime = 100
+                WorkoutGetDto.WorkoutResponse(
+                    dayOfWeek = "1",
+                    workout = WorkoutStorage.WorkoutByDay(
+                        workoutDate = "2023-06-22T10:00:00",
+                        totalTime = 60,
+                        averageHeartbeat = 120,
+                        totalCalories = 500,
+                        maxWorkoutCategory = WorkoutCategory.UP.name,
+                        maxWorkoutCategoryTime = 100
+                    )
                 )
             )
         )
@@ -155,13 +159,14 @@ class WorkoutControllerTest(
                     pathParameters(
                         parameterWithName("userId").description("친구 아이디: 본인 운동 데이터 조회에서는 필요 X").optional()
                     ),
-                        responseFields(
-                        fieldWithPath("workouts[].workoutDate").type(JsonFieldType.STRING).description("운동 날짜"),
-                        fieldWithPath("workouts[].totalTime").type(JsonFieldType.NUMBER).description("하루 동안 누적 운동 시간"),
-                        fieldWithPath("workouts[].averageHeartbeat").type(JsonFieldType.NUMBER).description("하루 동안 평균 심박수"),
-                        fieldWithPath("workouts[].totalCalories").type(JsonFieldType.NUMBER).description("하루 동안 누적 소모 칼로리"),
-                        fieldWithPath("workouts[].maxWorkoutCategory").type(JsonFieldType.STRING).description("하루 동안 최대 운동한 부위: WHOLE(전신) / UP(상체) / DOWN(하체) "),
-                        fieldWithPath("workouts[].maxWorkoutCategoryTime").type(JsonFieldType.NUMBER).description("하루 동안 최대 운동한 부위 시간")
+                    responseFields(
+                        fieldWithPath("workouts[].dayOfWeek").type(JsonFieldType.STRING).description("운동 요일 (월부터 1, 일요일은 7)"),
+                        fieldWithPath("workouts[].workout.workoutDate").type(JsonFieldType.STRING).description("운동 날짜"),
+                        fieldWithPath("workouts[].workout.totalTime").type(JsonFieldType.NUMBER).description("하루 동안 누적 운동 시간"),
+                        fieldWithPath("workouts[].workout.averageHeartbeat").type(JsonFieldType.NUMBER).description("하루 동안 평균 심박수"),
+                        fieldWithPath("workouts[].workout.totalCalories").type(JsonFieldType.NUMBER).description("하루 동안 누적 소모 칼로리"),
+                        fieldWithPath("workouts[].workout.maxWorkoutCategory").type(JsonFieldType.STRING).description("하루 동안 최대 운동한 부위: WHOLE(전신) / UP(상체) / DOWN(하체) "),
+                        fieldWithPath("workouts[].workout.maxWorkoutCategoryTime").type(JsonFieldType.NUMBER).description("하루 동안 최대 운동한 부위 시간")
                     )
                 )
             )


### PR DESCRIPTION
### ☁️ 개요
+ #90 

### 🎨 작업 내용
+ 응답 데이터 값에 요일 필드 추가
+ 존재하는 데이터만 반환하는 구조에서 7일 배열로 고정해서 반환
+ 기존에 크루 시작 날짜 기반으로 7일 고정해서 가져오는거에서, 현재 날짜 기반으로 각 주차별 7일치 데이터 반환하도록 로직 수정

### 🧚🏻 주의 사항
+ @gunh0 주차 계산해서 가져오도록 하는거 `CalenderUtils`랑 `Crew` 엔티티 안에 메서드 만들어놨으니 사용하면 되겠습니당...휴 힘들었다

### 이슈 닫기
close #90
